### PR TITLE
Removing handler to avoid memory problems

### DIFF
--- a/fair_eva/api/rda.py
+++ b/fair_eva/api/rda.py
@@ -94,34 +94,38 @@ def load_plugin(wrapped_func):
         evaluator_handler = ut.EvaluatorLogHandler()
         downstream_logger.addHandler(evaluator_handler)
 
-        # Load configuration
-        config_data = plugin_module.Plugin.load_config(f"{PLUGIN_PATH}.{plugin_name}")
+        try:
+            # Load configuration
+            config_data = plugin_module.Plugin.load_config(f"{PLUGIN_PATH}.{plugin_name}")
 
-        # Collect FAIR checks per metadata identifier
-        result = {}
-        exit_code = 200
-        for item_id in ids:
-            try:
-                eva = plugin_module.Plugin(
-                    item_id, api_endpoint, lang, name=plugin_name, config=config_data
+            # Collect FAIR checks per metadata identifier
+            result = {}
+            exit_code = 200
+            for item_id in ids:
+                try:
+                    eva = plugin_module.Plugin(
+                        item_id, api_endpoint, lang, name=plugin_name, config=config_data
+                    )
+                except Exception as e:
+                    message = f"Error while initiating {plugin_name} plugin: {e}"
+                    logger.error(message)
+                    return message, 400
+                _result, _exit_code = wrapped_func(body, eva=eva)
+                logger.debug(
+                    "Raw result returned for indicator ID '%s': %s" % (item_id, _result)
                 )
-            except Exception as e:
-                message = f"Error while initiating {plugin_name} plugin: {e}"
-                logger.error(message)
-                return message, 400
-            _result, _exit_code = wrapped_func(body, eva=eva)
-            logger.debug(
-                "Raw result returned for indicator ID '%s': %s" % (item_id, _result)
-            )
-            result[item_id] = _result
-            if _exit_code != 200:
-                exit_code = _exit_code
+                result[item_id] = _result
+                if _exit_code != 200:
+                    exit_code = _exit_code
 
-        # Append evaluator logs to the final results
-        result["evaluator_logs"] = evaluator_handler.logs
-        logger.debug("Evaluator logs appended through 'evaluator_logs' property")
+            # Append evaluator logs to the final results
+            result["evaluator_logs"] = evaluator_handler.logs
+            logger.debug("Evaluator logs appended through 'evaluator_logs' property")
 
-        return result, exit_code
+            return result, exit_code
+        finally:
+            # remove the handler from the downstream logger to avoid leak
+            downstream_logger.removeHandler(evaluator_handler)
 
     return wrapper
 

--- a/fair_eva/api/rda.py
+++ b/fair_eva/api/rda.py
@@ -96,7 +96,9 @@ def load_plugin(wrapped_func):
 
         try:
             # Load configuration
-            config_data = plugin_module.Plugin.load_config(f"{PLUGIN_PATH}.{plugin_name}")
+            config_data = plugin_module.Plugin.load_config(
+                f"{PLUGIN_PATH}.{plugin_name}"
+            )
 
             # Collect FAIR checks per metadata identifier
             result = {}
@@ -104,7 +106,11 @@ def load_plugin(wrapped_func):
             for item_id in ids:
                 try:
                     eva = plugin_module.Plugin(
-                        item_id, api_endpoint, lang, name=plugin_name, config=config_data
+                        item_id,
+                        api_endpoint,
+                        lang,
+                        name=plugin_name,
+                        config=config_data,
                     )
                 except Exception as e:
                     message = f"Error while initiating {plugin_name} plugin: {e}"
@@ -125,6 +131,7 @@ def load_plugin(wrapped_func):
             return result, exit_code
         finally:
             # remove the handler from the downstream logger to avoid leak
+            logger.debug("Removing handler from downstream_logger")
             downstream_logger.removeHandler(evaluator_handler)
 
     return wrapper

--- a/fair_eva/api/rda.py
+++ b/fair_eva/api/rda.py
@@ -96,7 +96,9 @@ def load_plugin(wrapped_func):
 
         try:
             # Load configuration
-            config_data = plugin_module.Plugin.load_config(f"{PLUGIN_PATH}.{plugin_name}")
+            config_data = plugin_module.Plugin.load_config(
+                f"{PLUGIN_PATH}.{plugin_name}"
+            )
 
             # Collect FAIR checks per metadata identifier
             result = {}
@@ -104,7 +106,11 @@ def load_plugin(wrapped_func):
             for item_id in ids:
                 try:
                     eva = plugin_module.Plugin(
-                        item_id, api_endpoint, lang, name=plugin_name, config=config_data
+                        item_id,
+                        api_endpoint,
+                        lang,
+                        name=plugin_name,
+                        config=config_data,
                     )
                 except Exception as e:
                     message = f"Error while initiating {plugin_name} plugin: {e}"


### PR DESCRIPTION
Trying to fix https://github.com/IFCA-Advanced-Computing/FAIR_eva/issues/281

The problem seems to be related to the logger. 
A handler is added in line 95
downstream_logger.addHandler(evaluator_handler)
but never removed. 
With repeated requests this may be leading to the observed leak.

A try block is added, with the removal of the Handler in the finally.


