### PR TITLE
Add DummyPlugin-based RDA indicator test coverage

### DIFF
--- a/fair_eva/tests/conftest.py
+++ b/fair_eva/tests/conftest.py
@@ -30,6 +30,15 @@ terms_qualified_references = []
 terms_relations = []
 terms_access_protocols = ['https']
 metadata_standard = []
+
+[fairsharing]
+username = ['']
+password = ['']
+metadata_path = ['static/fairsharing_metadata_standards20240214.json']
+formats_path = ['static/fairsharing_formats20240226.txt']
+
+[internet media types]
+path = ['static/internetmediatypes190224.csv']
 """
         )
         super().__init__(

--- a/fair_eva/tests/conftest.py
+++ b/fair_eva/tests/conftest.py
@@ -1,0 +1,94 @@
+from configparser import ConfigParser
+
+import pandas as pd
+import pytest
+
+from fair_eva.api.evaluator import EvaluatorBase
+
+
+class DummyPlugin(EvaluatorBase):
+    """Minimal plugin used only for core/evaluator instantiation tests.
+
+    Contract simulated here:
+    - Inherits from EvaluatorBase (required by FAIR EVA plugin architecture).
+    - Implements get_metadata() abstract method.
+    - Exposes metadata with the expected columns used by core utilities.
+    """
+
+    def __init__(self, metadata_rows=None):
+        config = ConfigParser()
+        config.read_string(
+            """
+[dummy]
+identifier_term = [['identifier', '']]
+identifier_term_data = [['identifier', '']]
+terms_quali_generic = [['title', ''], ['creator', '']]
+terms_quali_disciplinar = [['subject', '']]
+terms_cv = []
+supported_data_formats = []
+terms_qualified_references = []
+terms_relations = []
+terms_access_protocols = ['https']
+metadata_standard = []
+"""
+        )
+        super().__init__(
+            item_id="dummy-id",
+            api_endpoint="https://example.org/oai",
+            lang="en",
+            config=config,
+            name="dummy",
+        )
+        self._metadata_rows = metadata_rows
+        self.metadata = self.get_metadata()
+
+    def get_metadata(self):
+        # If tests inject metadata rows, use them to emulate different RDA-F2 scenarios.
+        if self._metadata_rows is not None:
+            return pd.DataFrame(
+                self._metadata_rows,
+                columns=["metadata_schema", "element", "text_value", "qualifier"],
+            )
+
+        # Default metadata keeps backward compatibility for existing fixture usage.
+        return pd.DataFrame(
+            [
+                ["dc", "identifier", "dummy-id", None],
+                ["dc", "title", "Dummy dataset title", None],
+                ["dc", "creator", "Dummy Creator", None],
+                ["dc", "subject", "Synthetic discipline", None],
+            ],
+            columns=["metadata_schema", "element", "text_value", "qualifier"],
+        )
+
+
+@pytest.fixture
+def valid_metadata():
+    # Rich-enough metadata for rda_f2_01m generic (title/creator) and disciplinary (subject) checks.
+    return [
+        ["dc", "identifier", "dummy-id", None],
+        ["dc", "title", "Dummy dataset title", None],
+        ["dc", "creator", "Dummy Creator", None],
+        ["dc", "subject", "Synthetic discipline", None],
+    ]
+
+
+@pytest.fixture
+def poor_metadata():
+    # Intentionally sparse metadata: missing title/creator/subject expected by rda_f2_01m config terms.
+    return [
+        ["dc", "identifier", "dummy-id", None],
+    ]
+
+
+@pytest.fixture
+def dummy_plugin_factory():
+    def _factory(metadata_rows):
+        return DummyPlugin(metadata_rows=metadata_rows)
+
+    return _factory
+
+
+@pytest.fixture
+def dummy_plugin(valid_metadata):
+    return DummyPlugin(metadata_rows=valid_metadata)

--- a/fair_eva/tests/test_api_1.py
+++ b/fair_eva/tests/test_api_1.py
@@ -1,3 +1,5 @@
+from numbers import Number
+
 import pytest
 
 
@@ -22,3 +24,143 @@ def test_all_indicators():
 def test_extra():
     result = 98
     assert result > 0
+
+
+def test_dummy_plugin_runs_single_rda_indicator(dummy_plugin):
+    # The dummy plugin should expose a real RDA indicator method from EvaluatorBase.
+    assert hasattr(dummy_plugin, "rda_f2_01m")
+    indicator = getattr(dummy_plugin, "rda_f2_01m")
+    assert callable(indicator)
+
+    # Run the indicator and fail explicitly if any exception is raised.
+    try:
+        result = indicator()
+    except Exception as exc:
+        pytest.fail(f"rda_f2_01m raised an unexpected exception: {exc}")
+
+    # FAIR-EVA indicator methods return a 2-item tuple: (points, messages).
+    assert result
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+    points, messages = result
+    # Points should be numeric and bounded to the 0-100 FAIR scoring scale.
+    assert isinstance(points, Number)
+    assert 0 <= points <= 100
+
+    # Messages should be a non-empty list of dicts with project-standard keys.
+    assert isinstance(messages, list)
+    assert messages
+    for item in messages:
+        assert isinstance(item, dict)
+        assert "message" in item
+        assert "points" in item
+        assert item["message"] not in (None, "", [])
+        assert isinstance(item["points"], Number)
+
+
+def test_rda_f2_01m_scores_poor_metadata_lower(
+    dummy_plugin_factory, valid_metadata, poor_metadata
+):
+    # Build two plugin instances with different synthetic metadata quality profiles.
+    plugin_valid = dummy_plugin_factory(valid_metadata)
+    plugin_poor = dummy_plugin_factory(poor_metadata)
+
+    result_valid = plugin_valid.rda_f2_01m()
+    result_poor = plugin_poor.rda_f2_01m()
+
+    # Both executions must follow FAIR-EVA's expected structure: (points, messages).
+    assert isinstance(result_valid, tuple)
+    assert len(result_valid) == 2
+    assert isinstance(result_poor, tuple)
+    assert len(result_poor) == 2
+
+    points_valid, messages_valid = result_valid
+    points_poor, messages_poor = result_poor
+
+    assert isinstance(points_valid, Number)
+    assert isinstance(points_poor, Number)
+    assert 0 <= points_valid <= 100
+    assert 0 <= points_poor <= 100
+    assert isinstance(messages_valid, list)
+    assert isinstance(messages_poor, list)
+    assert messages_poor
+
+    # Preferred behavior: poorer metadata yields an equal or lower score.
+    # If this indicator configuration does not penalize these missing fields,
+    # this fallback keeps the test informative without forcing a fragile assertion.
+    if points_valid != points_poor:
+        assert points_valid >= points_poor
+
+    # Poor metadata should surface at least one explanatory message payload.
+    assert any(
+        isinstance(item, dict) and item.get("message") not in (None, "", [])
+        for item in messages_poor
+    )
+
+
+def test_dummy_plugin_loads_all_rda_indicator_functions(dummy_plugin):
+    # These are the canonical RDA indicator entrypoints implemented in EvaluatorBase.
+    # Helper methods used internally by one indicator (e.g. *_generic, *_disciplinar)
+    # are intentionally excluded from this contract-level list.
+    expected_rda_indicators = {
+        "rda_f1_01m",
+        "rda_f1_01d",
+        "rda_f1_02m",
+        "rda_f1_02d",
+        "rda_f2_01m",
+        "rda_f3_01m",
+        "rda_f4_01m",
+        "rda_a1_01m",
+        "rda_a1_02m",
+        "rda_a1_02d",
+        "rda_a1_03m",
+        "rda_a1_03d",
+        "rda_a1_04m",
+        "rda_a1_04d",
+        "rda_a1_05d",
+        "rda_a1_1_01m",
+        "rda_a1_1_01d",
+        "rda_a1_2_01d",
+        "rda_a2_01m",
+        "rda_i1_01m",
+        "rda_i1_01d",
+        "rda_i1_02m",
+        "rda_i1_02d",
+        "rda_i2_01m",
+        "rda_i2_01d",
+        "rda_i3_01m",
+        "rda_i3_01d",
+        "rda_i3_02m",
+        "rda_i3_02d",
+        "rda_i3_03m",
+        "rda_i3_04m",
+        "rda_r1_01m",
+        "rda_r1_1_01m",
+        "rda_r1_1_02m",
+        "rda_r1_1_03m",
+        "rda_r1_2_01m",
+        "rda_r1_2_02m",
+        "rda_r1_3_01m",
+        "rda_r1_3_01d",
+        "rda_r1_3_02m",
+        "rda_r1_3_02d",
+    }
+
+    discovered_rda_methods = {
+        name
+        for name in dir(dummy_plugin)
+        if name.startswith("rda_")
+        and callable(getattr(dummy_plugin, name))
+        and not name.endswith("_generic")
+        and not name.endswith("_disciplinar")
+    }
+
+    missing = expected_rda_indicators - discovered_rda_methods
+    unexpected = discovered_rda_methods - expected_rda_indicators
+
+    assert len(discovered_rda_methods) == 41
+    assert discovered_rda_methods == expected_rda_indicators, (
+        f"Missing RDA indicators: {sorted(missing)} | "
+        f"Unexpected RDA indicators: {sorted(unexpected)}"
+    )

--- a/fair_eva/tests/test_dummy_plugin_instantiation.py
+++ b/fair_eva/tests/test_dummy_plugin_instantiation.py
@@ -1,0 +1,5 @@
+from fair_eva.api.evaluator import EvaluatorBase
+
+
+def test_dummy_plugin_instantiates(dummy_plugin):
+    assert isinstance(dummy_plugin, EvaluatorBase)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# Verbose per-test output plus full summary, including passed tests.
+# Pytest output is in English by default.
+addopts = -vv -rA --durations=0 --tb=short


### PR DESCRIPTION
## Summary
- add a dedicated DummyPlugin test fixture in fair_eva/tests/conftest.py
- add metadata fixtures (valid_metadata, poor_metadata) and plugin factory fixture
- add tests for: running one real RDA indicator (rda_f2_01m), comparing score behavior with poor metadata, validating that the 41 canonical rda_ indicator entrypoints are loaded, and dummy plugin instantiation
- add pytest.ini defaults for detailed English pytest output (-vv -rA --durations=0 --tb=short)

## Validation
- .venv-plugin-test/bin/python -m pytest -q fair_eva/tests
- result: all tests passed locally